### PR TITLE
automake: Don't include locally generated COPYING symlink in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ compile
 test-driver
 
 # build directory
-OBJ
+OBJCOPYING

--- a/COPYING
+++ b/COPYING
@@ -1,1 +1,0 @@
-/usr/local/Cellar/automake/1.16.1_1/share/automake-1.16/COPYING


### PR DESCRIPTION
currently, COPYING is a symlink to `/usr/local/Cellar/automake/1.16.1_1/share/automake-1.16/COPYING`, and that's a) pretty useless on any other machine than that where automake was run, and b) it's redundant and even contradicting (GPLv3+ vs GPLv2+) to what COPYRIGHT contains.

Solution: remove erroneously included COPYING, add to gitignore.

Signed-off-by: Marcus Müller <marcus@hostalia.de>
