### PR TITLE
F77, benchee/{dsp,sciport}: use -std=legacy to compile on modern gfortran

### DIFF
--- a/benchees/dsp/Makefile.am
+++ b/benchees/dsp/Makefile.am
@@ -9,6 +9,7 @@ PKG=dsp
 TARFILE=$(PKG).tar.gz
 EXTRA_DIST = $(TARFILE) sect17.f sect18.f
 AM_CPPFLAGS = $(INCLBENCH)
+AM_FFLAGS=@LEGACY_FFLAGS@
 LOCAL_COPIES=sect04.f sect11.f sect12.f sect13.f sect14.f sect16.f	\
 sect19.f
 

--- a/benchees/sciport/Makefile.am
+++ b/benchees/sciport/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = readme ffts.f fftd.f ffts.patch fftd.patch
 LOCAL_COPIES = ffts-patched.f fftd-patched.f
 
 AM_CPPFLAGS = $(INCLBENCH)
+AM_FFLAGS = @LEGACY_FFLAGS@
 
 doit_SOURCES=doit.c
 doit_LDADD=$(LIBFFT) $(LIBBENCH) @FLIBS@

--- a/configure.ac
+++ b/configure.ac
@@ -65,8 +65,14 @@ if test -n "$F77"; then
 	else
 		AC_F77_WRAPPERS
 		AX_F77_CMAIN_FFLAGS
+
+		dnl for gfortran to compile old code
+		AC_LANG_PUSH(Fortran 77)
+		AX_CHECK_COMPILER_FLAGS(-std=legacy, LEGACY_FFLAGS="-std=legacy")
+		AC_LANG_POP(Fortran 77)
 	fi
 fi
+AC_SUBST(LEGACY_FFLAGS)
 
 AC_PROG_FC([], [Fortran 90])
 if test -n "$FC"; then


### PR DESCRIPTION
Fixes #9

After this, I only have one "expectedly" failing benchee, vbigdsp, and one "unexpectedly" failing, green-ffts-2.0

Signed-off-by: Marcus Müller <marcus@hostalia.de>
