### PR TITLE
Fix warning with BENCH_ASSERT for C++11.

### DIFF
--- a/libbench/bench-user.h
+++ b/libbench/bench-user.h
@@ -185,7 +185,7 @@ extern int paranoid;
 /**************************************************************
  * assert
  **************************************************************/
-extern void bench_assertion_failed(const char *s, int line, char *file);
+extern void bench_assertion_failed(const char *s, int line, const char *file);
 #define BENCH_ASSERT(ex)						 \
       (void)((ex) || (bench_assertion_failed(#ex, __LINE__, __FILE__), 0))
 

--- a/libbench/util.c
+++ b/libbench/util.c
@@ -33,7 +33,7 @@
 #include <malloc.h>
 #endif
 
-void bench_assertion_failed(const char *s, int line, char *file)
+void bench_assertion_failed(const char *s, int line, const char *file)
 {
      fflush(stdout);
      fprintf(stderr, "bench: %s:%d: assertion failed: %s\n", file, line, s);


### PR DESCRIPTION
C++11 does not allow a C-style literal string to be passed to a function having a non-const char* parameter.
Since this function does not modify 'file', the fix is easy and allows us to compile your code using a C++ compiler.