### PR TITLE
Add batch support, improve random generation, improve multiprecision trig.

### DIFF
--- a/benchees/intel-ipps/Makefile.am
+++ b/benchees/intel-ipps/Makefile.am
@@ -1,25 +1,11 @@
 if HAVE_IPPS
-PRG32=doit
+PRG=doit
 endif
 
-if HAVE_IPPSEM64T
-PRGEM64T=doitem64t
-endif
-
-if HAVE_IPPS64
-PRG64=doit64
-endif
-
-PRG=$(PRG32) $(PRGEM64T) $(PRG64)
 AM_CPPFLAGS = $(INCLBENCH)
 
 doit_SOURCES=doit.c
-doit_LDADD=-lipps $(LIBBENCH) @FLIBS@
 
-doitem64t_SOURCES=doit.c
-doitem64t_LDADD=-lippsem64t $(LIBBENCH) @FLIBS@
-
-doit64_SOURCES=doit.c
-doit64_LDADD=-lipps64 $(LIBBENCH) @FLIBS@
+doit_LDADD=-lipps -lippcore $(LIBBENCH)
 
 include ../Makefile.common

--- a/benchees/intel-ipps/doit.c
+++ b/benchees/intel-ipps/doit.c
@@ -45,7 +45,7 @@ static void *buffer;
 
 int can_do(struct problem *p)
 {
-    return (p->rank == 1 &&
+    return (p->rank == 1 && p->vrank == 0 && p->batch == 1 &&
 	    (problem_power_of_two(p, 0) || problem_power_of_two(p, 1)) );
 }
 

--- a/benchees/intel-mkl/doit_dfti.c
+++ b/benchees/intel-mkl/doit_dfti.c
@@ -27,11 +27,11 @@ END_BENCH_DOC
 
 DFTI_DESCRIPTOR *the_descriptor;
 
-#define ERROR_CHECK							\
-     if (!DftiErrorClass(status, DFTI_NO_ERROR)) {			\
-	  if (verbose > 3)						\
-	       printf("DFTI error: %s\n", DftiErrorMessage(status));	\
-	  return 0;							\
+#define ERROR_CHECK                                                 \
+     if (!DftiErrorClass(status, DFTI_NO_ERROR)) {                  \
+         if (verbose > 3)                                           \
+             printf("DFTI error: %s\n", DftiErrorMessage(status));  \
+         return 0;                                                  \
      }
 
 #define MAXRNK 7 /* or so the paper claims */
@@ -40,80 +40,94 @@ static int mkdescriptor(struct problem *p)
      long status;
      enum DFTI_CONFIG_VALUE domain;
      long pn[MAXRNK];
+     long batch_distance = 1;
      int i;
 
-     the_descriptor = 0;
-
      if (p->rank > MAXRNK)
-	  return 0;
+         return 0;
 
-     for (i = 0; i < p->rank; ++i)
-	  pn[i] = p->n[i]; /* convert int -> long */
-
-     if (p->kind == PROBLEM_COMPLEX) {
-	  domain = DFTI_COMPLEX;
-     } else {
-	  domain = DFTI_REAL;
+     if (p->vrank) {
+         return 0;  /* batch_distance, below, assumes vrank == 0 */
      }
-     
-     /* api nonsense */
-     if (p->rank == 1) 
-	  status = DftiCreateDescriptor(&the_descriptor,
-					PRECISION,
-					domain,
-					1,
-					pn[0]);
-     else 
-	  status = DftiCreateDescriptor(&the_descriptor,
-					PRECISION,
-					domain,
-					p->rank,
-					pn);
+
+     for (i = 0; i < p->rank; ++i) {
+        pn[i] = p->n[i]; /* convert int -> long */
+        batch_distance *= pn[i];
+     }
+
+     domain = (p->kind == PROBLEM_COMPLEX) ? DFTI_COMPLEX : DFTI_REAL;
+
+     the_descriptor = 0;
+     if (p->rank == 1)
+         status = DftiCreateDescriptor(&the_descriptor, PRECISION, domain,
+                                       1, pn[0]);
+     else
+         status = DftiCreateDescriptor(&the_descriptor, PRECISION, domain,
+                                       p->rank, pn);
      ERROR_CHECK;
 
-     status = DftiSetValue(the_descriptor, DFTI_PLACEMENT, 
-			   problem_in_place(p) ? 
-			   DFTI_INPLACE : DFTI_NOT_INPLACE);
+     status = DftiSetValue(the_descriptor, DFTI_PLACEMENT,
+                  problem_in_place(p) ? DFTI_INPLACE : DFTI_NOT_INPLACE);
      ERROR_CHECK;
 
-     status = DftiSetValue(the_descriptor,
-			   DFTI_CONJUGATE_EVEN_STORAGE, 
-			   DFTI_COMPLEX_COMPLEX);
+     status = DftiSetValue(the_descriptor, DFTI_NUMBER_OF_TRANSFORMS,
+                           p->batch);
      ERROR_CHECK;
-
-     /* we are already benchmarking CCS in doit.c */
-     status = DftiSetValue(the_descriptor, DFTI_PACKED_FORMAT, 
-			   DFTI_CCE_FORMAT);
-     ERROR_CHECK;
-
 
      if (p->kind == PROBLEM_REAL) {
-	  /* these guys must be kidding */
-	  long strides[MAXRNK+1];
+         status = DftiSetValue(the_descriptor, DFTI_CONJUGATE_EVEN_STORAGE,
+                               DFTI_COMPLEX_COMPLEX);
+         ERROR_CHECK;
 
-	  strides[p->rank] = 1;
-	  if (p->rank > 0) {
-	       strides[p->rank - 1] = pn[p->rank - 1] / 2 + 1;
+         long cstrides[MAXRNK+1];
+         long rstrides[MAXRNK+1];
+         cstrides[p->rank] = 1;
+         rstrides[p->rank] = 1;
+         if (p->rank > 0) {
+             cstrides[p->rank - 1] = pn[p->rank - 1] / 2 + 1;
+             if (problem_in_place(p)) {
+                 rstrides[p->rank - 1] = 2 * cstrides[p->rank - 1];
+             } else {
+                 rstrides[p->rank - 1] = pn[p->rank - 1];
+             }
 
-	       for (i = p->rank - 2; i > 0; --i) 
-		    strides[i] = strides[i+1] * pn[i];
+             for (i = p->rank - 2; i >= 0; --i) {
+                 cstrides[i] = cstrides[i+1] * pn[i];
+                 rstrides[i] = rstrides[i+1] * pn[i];
+             }
+         }
 
-	       /* if this is not zero the thing doesn't work */
-	       strides[0] = 0;
-	  }
-	  
-	  status = DftiSetValue(the_descriptor, 
-				(p->sign > 0 ? 
-				 DFTI_INPUT_STRIDES : DFTI_OUTPUT_STRIDES), 
-				strides);
-	  ERROR_CHECK;
+         status = DftiSetValue(the_descriptor,
+                      p->sign > 0 ? DFTI_INPUT_DISTANCE : DFTI_OUTPUT_DISTANCE,
+                      cstrides[0]);
+         ERROR_CHECK;
+
+         status = DftiSetValue(the_descriptor,
+                      p->sign > 0 ? DFTI_OUTPUT_DISTANCE : DFTI_INPUT_DISTANCE,
+                      rstrides[0]);
+         ERROR_CHECK;
+
+         cstrides[0] = 0;
+         rstrides[0] = 0;
+
+         status = DftiSetValue(the_descriptor,
+                      p->sign > 0 ? DFTI_INPUT_STRIDES : DFTI_OUTPUT_STRIDES,
+                      cstrides);
+         ERROR_CHECK;
+
+         status = DftiSetValue(the_descriptor,
+                      p->sign > 0 ? DFTI_OUTPUT_STRIDES : DFTI_INPUT_STRIDES,
+                      rstrides);
+         ERROR_CHECK;
+     } else {
+         status = DftiSetValue(the_descriptor, DFTI_INPUT_DISTANCE,
+                               batch_distance);
+         ERROR_CHECK;
+
+         status = DftiSetValue(the_descriptor, DFTI_OUTPUT_DISTANCE,
+                               batch_distance);
+         ERROR_CHECK;
      }
-
-#if 0
-     /* this disappeared in mkl 8 */
-     DftiSetValue(the_descriptor, DFTI_INITIALIZATION_EFFORT, DFTI_HIGH);
-     ERROR_CHECK;
-#endif
 
      status = DftiCommitDescriptor(the_descriptor);
      ERROR_CHECK;
@@ -127,11 +141,11 @@ int can_do(struct problem *p)
 
      /* ask mkl whether it can do it or not */
      if (mkdescriptor(p)) {
-	  if (the_descriptor)
-	       DftiFreeDescriptor(&the_descriptor);
-	  return 1;
-     } else 
-	  return 0;
+         if (the_descriptor)
+             DftiFreeDescriptor(&the_descriptor);
+         return 1;
+     } else
+         return 0;
 }
 
 
@@ -148,24 +162,27 @@ void copy_c2h(struct problem *p, bench_complex *in)
 void copy_r2c(struct problem *p, bench_complex *out)
 {
      if (problem_in_place(p))
-	  copy_r2c_unpacked(p, out);	  
+         copy_r2c_unpacked(p, out);
      else
-	  copy_r2c_packed(p, out);
+         copy_r2c_packed(p, out);
 }
 
 void copy_c2r(struct problem *p, bench_complex *in)
 {
      if (problem_in_place(p))
-	  copy_c2r_unpacked(p, in);
+         copy_c2r_unpacked(p, in);
      else
-	  copy_c2r_packed(p, in);
+         copy_c2r_packed(p, in);
 }
 
 void setup(struct problem *p)
 {
      int status;
-	 mkl_set_num_threads(1); /* all benchmarks measure only single-threaded performance */
-	 status = mkdescriptor(p);
+     /* To measure single-threaded performance, set the environment variable *
+      *     MKL_NUM_THREADS=1                                                *
+      * or uncomment the function call on the following line.                */
+     /* mkl_set_num_threads(1); */
+     status = mkdescriptor(p);
 
      BENCH_ASSERT(status);
 }
@@ -176,21 +193,21 @@ void doit(int iter, struct problem *p)
      DFTI_DESCRIPTOR *d = the_descriptor;
 
      if (p->in_place) {
-	  if (p->sign == -1) {
-	       for (i = 0; i < iter; ++i) 
-		    DftiComputeForward(d, p->in);
-	  } else {
-	       for (i = 0; i < iter; ++i) 
-		    DftiComputeBackward(d, p->in);
-	  }
+         if (p->sign == -1) {
+             for (i = 0; i < iter; ++i)
+                 DftiComputeForward(d, p->in);
+         } else {
+             for (i = 0; i < iter; ++i)
+                 DftiComputeBackward(d, p->in);
+         }
      } else {
-	  if (p->sign == -1) {
-	       for (i = 0; i < iter; ++i) 
-		    DftiComputeForward(d, p->in, p->out);
-	  } else {
-	       for (i = 0; i < iter; ++i) 
-		    DftiComputeBackward(d, p->in, p->out);
-	  }
+         if (p->sign == -1) {
+             for (i = 0; i < iter; ++i)
+                 DftiComputeForward(d, p->in, p->out);
+         } else {
+             for (i = 0; i < iter; ++i)
+                 DftiComputeBackward(d, p->in, p->out);
+         }
      }
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -114,13 +114,11 @@ AC_FUNC_VPRINTF
 AC_CHECK_LIB(m, sin)
 AC_CHECK_FUNCS(BSDgettimeofday)
 AC_CHECK_FUNCS(gettimeofday)
-AC_CHECK_FUNCS(drand48)
 AC_CHECK_FUNCS(hypot)
 AC_CHECK_FUNCS(sqrt)
 AC_CHECK_FUNCS(strtod)
 AC_CHECK_FUNCS(memset)
 AC_CHECK_FUNCS(memalign)
-AC_CHECK_DECLS(drand48)
 AC_CHECK_DECLS(hypot,[],[],[#include <math.h>])
 
 # Check for installed libraries

--- a/configure.ac
+++ b/configure.ac
@@ -255,20 +255,14 @@ AC_CHECK_LIB(mkl_rt, zfft1d_, [have_mkl=yes])
 AM_CONDITIONAL(HAVE_MKL, test -n "$have_mkl")
 AC_CHECK_LIB(mkl_rt, DftiCreateDescriptor, [have_mkl_dfti=yes])
 AM_CONDITIONAL(HAVE_MKL_DFTI, test -n "$have_mkl_dfti")
-
 AC_CHECK_HEADERS(mkl_dfti.h)
 AC_CHECK_HEADERS(mkl_fft.h)
 AC_CHECK_HEADERS(mkl_blas.h)
 
-
-# Check for Intel's IPP library:
+# Check for Intel's IPP Signal processing library:
 AC_CHECK_HEADERS(ipps.h)
-AC_CHECK_LIB(ipps, ippsGetLibVersion, [have_ipps=yes])
+AC_CHECK_LIB(ipps, ippsGetLibVersion, [have_ipps=yes], [], -lippcore)
 AM_CONDITIONAL(HAVE_IPPS, test -n "$have_ipps")
-AC_CHECK_LIB(ippsem64t, ippsGetLibVersion, [have_ippsem64t=yes])
-AM_CONDITIONAL(HAVE_IPPSEM64T, test -n "$have_ippsem64t")
-AC_CHECK_LIB(ipps64, ippsGetLibVersion, [have_ipps64=yes])
-AM_CONDITIONAL(HAVE_IPPS64, test -n "$have_ipps64")
 
 # check for Numerical Recipes source in benchees/nr
 nr_dir=$srcdir/benchees/nr
@@ -292,7 +286,6 @@ if test "x$FFMPEG_CONFIG" = "xffmpeg-config"; then
   AC_SUBST(FFMPEG_LIBS)
 fi
 AM_CONDITIONAL(HAVE_FFMPEG, test -n "$have_ffmpeg")
-
 
 dnl Check for SCSL library (SGI/Cray Scientific Library):
 AC_CHECK_LIB(scs, zzfft)
@@ -472,8 +465,7 @@ benchees/vdsp/Makefile
 
 cat <<EOF
 *******************************************************************************
-		    Optional FFT libraries Found:
-
+ Optional FFT libraries Found:
                                        DXML/CXML (Alpha only): ${have_dxml-no}
                                     HP MLIB (PA-RISC/Itanium): ${have_mlib-no}
                          Sun Performance Library (SPARC only): ${have_sunperf-no}
@@ -487,10 +479,8 @@ cat <<EOF
        Numerical Recipes in Fortran (proprietary, www.nr.com): ${have_nrf-no}
 
       Intel MKL (gratis, www.intel.com/software/products/mkl): ${have_mkl-no}
-                                   Intel MKL, DFTI interface : ${have_mkl_dfti-no}
-                                          Intel IPPS (gratis): ${have_ipps-no}
-                                    Intel IPPS em64t (gratis): ${have_ippsem64t-no}
-                                   Intel IPPS 64 bit (gratis): ${have_ipps64-no}
+      Intel MKL, DFTI interface (gratis,       .            ): ${have_mkl_dfti-no}
+     Intel IPPS (gratis, www.intel.com/software/products/ipp): ${have_ipps-no}
                                             AMD ACML (gratis): ${have_acml-no}
 
                                 FFTW 2.x (free, www.fftw.org): ${have_fftw2_all-no}

--- a/libbench/allocate.c
+++ b/libbench/allocate.c
@@ -17,12 +17,12 @@ void problem_alloc(struct problem *p)
 	  size_t s = p->size * p->vsize;
 
 	  p->phys_size = s;
-	  p->in = bench_malloc(s * sizeof(bench_complex));
+	  p->in = bench_malloc(p->batch * s * sizeof(bench_complex));
 	  
 	  if (p->in_place)
 	       p->out = p->in;
 	  else
-	       p->out = bench_malloc(s * sizeof(bench_complex));
+	       p->out = bench_malloc(p->batch * s * sizeof(bench_complex));
      } else {
 	  size_t s = p->vsize;
 	  unsigned int i;
@@ -32,10 +32,10 @@ void problem_alloc(struct problem *p)
 	       s *= p->n[i] + 2;
 
 	  p->phys_size = s;
-	  p->in = bench_malloc(s * sizeof(bench_real));
+	  p->in = bench_malloc(p->batch * s * sizeof(bench_real));
 	  if (p->in_place)
 	       p->out = p->in;
 	  else
-	       p->out = bench_malloc(s * sizeof(bench_real));
+	       p->out = bench_malloc(p->batch * s * sizeof(bench_real));
      }
 }

--- a/libbench/bench-user.h
+++ b/libbench/bench-user.h
@@ -71,6 +71,7 @@ struct problem {
      unsigned int vn[MAX_RANK];  
      unsigned int vsize;  /* total vector size of input = PROD vn[i] */
      unsigned int phys_size;  /* total size of allocated input */
+     unsigned int batch;  /* batch sizes */
      int sign;
      int in_place;
      int split;

--- a/libbench/mflops.c
+++ b/libbench/mflops.c
@@ -11,10 +11,10 @@ double mflops(const struct problem *p, double t)
      switch (p->kind) {
 	 case PROBLEM_COMPLEX:
 	      return (5.0 * p->vsize * p->size * log((double) p->size) / 
-		      (log(2.0) * t * 1.0e6));
+		      (log(2.0) * t * 1.0e6)) * p->batch;
 	 case PROBLEM_REAL:
 	      return (2.5 * p->vsize * p->size * log((double) p->size) / 
-		      (log(2.0) * t * 1.0e6));
+		      (log(2.0) * t * 1.0e6)) * p->batch;
      }
      BENCH_ASSERT(0 /* can't happen */);
      return 0.0;

--- a/libbench/problem.c
+++ b/libbench/problem.c
@@ -80,6 +80,7 @@ struct problem *problem_parse(const char *s)
      p->userinfo = 0;
      p->rank = 0;
      p->vrank = 0;
+     p->batch = 1;
      p->size = 1;      /* the product of 0 things is 1 */
      p->vsize = 1;      /* the product of 0 things is 1 */
      p->pstring = (char *) bench_malloc(sizeof(char) * (strlen(s) + 1));
@@ -132,6 +133,13 @@ struct problem *problem_parse(const char *s)
 	       ++s;
 	       goto L4;
 	  }
+     }
+
+     /* parse batching (how many transforms) */
+     if (*s == 'b' || *s == 'B') {
+          ++s;
+          s = parseint(s, &n);
+          p->batch = n;
      }
 
      return p;

--- a/libbench/verify.c
+++ b/libbench/verify.c
@@ -481,7 +481,7 @@ static void do_accuracy(struct problem *p, int rounds)
 
      fftaccuracy_done();
 
-     ovtpvt("%6.2e %6.2e %6.2e %6.2e %6.2e %6.2e\n", 
+     ovtpvt("%.3e %.3e %.3e %.3e %.3e %.3e\n",
 	    t[0], t[1], t[2], t[3], t[4], t[5]);
 
 }

--- a/libbench/verify.c
+++ b/libbench/verify.c
@@ -206,6 +206,13 @@ static double acmp(bench_complex *A, bench_complex *B, unsigned int n,
 
 static void do_fft(struct problem *p, bench_complex *in, bench_complex *out)
 {
+     /* Note that do_verify() only initializes (and verifies) the first
+      * transform in a batch.  Prevent round-off errors from accumulating
+      * (and overflowing) in the problem I/O arrays for the others.
+      */
+     if (p->batch > 1)
+         problem_zero(p);
+
      problem_ccopy_from(p, in);
      doit(1, p);
      problem_ccopy_to(p, out);
@@ -395,6 +402,9 @@ static void do_verify(struct problem *p, unsigned int rounds, double tol)
      unsigned int n = p->size;
      double el, ei, es = 0.0;
 
+     /* only works for these cases */
+     BENCH_ASSERT(p->vrank == 0);
+
      if (rounds == 0)
 	  rounds = 20;  /* default value */
 
@@ -444,6 +454,7 @@ static void do_accuracy(struct problem *p, int rounds)
      double t[6], err[6];  
 
      /* only works for these cases */
+     BENCH_ASSERT(p->batch == 1);
      BENCH_ASSERT(p->rank == 1);
      BENCH_ASSERT(p->vrank == 0);
 

--- a/libbench/zero.c
+++ b/libbench/zero.c
@@ -28,10 +28,12 @@ void problem_zero(struct problem *p)
 {
      if (p->kind == PROBLEM_COMPLEX) {
 	  const bench_complex czero = {0, 0};
-	  caset(p->out, p->phys_size, czero);
-	  caset(p->in, p->phys_size, czero);
+	  caset(p->out, p->phys_size * p->batch, czero);
+          if (p->in != p->out)
+              caset(p->in, p->phys_size * p->batch, czero);
      } else {
-	  aset(p->out, p->phys_size, 0.0);
-	  aset(p->in, p->phys_size, 0.0);
+	  aset(p->out, p->phys_size * p->batch, 0.0);
+          if (p->in != p->out)
+              aset(p->in, p->phys_size * p->batch, 0.0);
      }
 }


### PR DESCRIPTION
This PR consists of three commits:

* Add support to benchmark a batch of FFTs.
* Replace system drand48() with portable C code RNG.
* Improved accuracy of multiprecision trig.

Note that batch support was added to libbench and to the fftw3 and intel-mkl benchees.
Note that floating point random numbers are generated by directly setting significand bits from a uniform distribution.  The bit generator is xoshiro256plus.  (Note that doubles have more than 48 bits to set.)
Note that the accuracy of the multiprecision trig functions is improved by roughly 10 bits and also is slightly faster.
Also, in that file, REAL is defined to be double, to match the output precision of fftaccuracy() as well as the definition of BITS_IN_REAL.
Please feel free to modify the copyright notice at the top of the file as you wish.  The GPL says I should add my name, but there was nothing there....